### PR TITLE
Allow pinch zoom on mobile result view

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,8 +34,8 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
+  maximumScale: 5,
+  userScalable: true,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- allow mobile browsers to zoom by increasing the viewport maximum scale
- re-enable user scaling so the finished image can be inspected more easily

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddc2105b648325b37fa2e61304eac8