### PR TITLE
Add freestyle image editing mode

### DIFF
--- a/src/app/api/freestyle-edit/route.ts
+++ b/src/app/api/freestyle-edit/route.ts
@@ -1,0 +1,154 @@
+import { NextResponse } from "next/server";
+import { GoogleGenAI, Part } from "@google/genai";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/auth";
+import { MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_MB, resolveMimeType } from "@/utils/server/imageValidation";
+
+export const runtime = "nodejs";
+
+const DEFAULT_MODEL = process.env.GEMINI_IMAGE_MODEL ?? "gemini-2.5-flash-image-preview";
+const MAX_IMAGE_COUNT = 5;
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return NextResponse.json(
+      { error: "認証が必要です。" },
+      { status: 401 },
+    );
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY;
+
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "Gemini API キーが設定されていません。" },
+      { status: 500 },
+    );
+  }
+
+  const formData = await request.formData();
+  const prompt = formData.get("prompt");
+  const imageEntries = formData.getAll("images");
+  const additionalImage = formData.get("image");
+
+  const files: File[] = imageEntries.filter((entry): entry is File => entry instanceof File);
+
+  if (files.length === 0 && additionalImage instanceof File) {
+    files.push(additionalImage);
+  }
+
+  if (typeof prompt !== "string" || prompt.trim().length === 0) {
+    return NextResponse.json(
+      { error: "編集内容を入力してください。" },
+      { status: 400 },
+    );
+  }
+
+  if (files.length === 0) {
+    return NextResponse.json(
+      { error: "画像を1枚以上アップロードしてください。" },
+      { status: 400 },
+    );
+  }
+
+  if (files.length > MAX_IMAGE_COUNT) {
+    return NextResponse.json(
+      { error: `画像は最大${MAX_IMAGE_COUNT}枚までアップロードできます。` },
+      { status: 400 },
+    );
+  }
+
+  const trimmedPrompt = prompt.trim();
+
+  try {
+    const client = new GoogleGenAI({ apiKey });
+
+    const parts: Part[] = [];
+
+    for (let index = 0; index < files.length; index += 1) {
+      const file = files[index];
+
+      if (file.size === 0) {
+        return NextResponse.json(
+          { error: `画像${index + 1}が空のファイルでした。別の画像をお試しください。` },
+          { status: 400 },
+        );
+      }
+
+      if (file.size > MAX_FILE_SIZE_BYTES) {
+        return NextResponse.json(
+          {
+            error: `画像${index + 1}のサイズが大きすぎます。${MAX_FILE_SIZE_MB}MB 以下の画像をご利用ください。`,
+          },
+          { status: 413 },
+        );
+      }
+
+      const resolvedMimeType = resolveMimeType(file);
+
+      if (!resolvedMimeType) {
+        return NextResponse.json(
+          {
+            error: `画像${index + 1}の形式がサポート対象外です。JPG、PNG、WebP形式の画像をご利用ください。`,
+          },
+          { status: 415 },
+        );
+      }
+
+      const buffer = Buffer.from(await file.arrayBuffer());
+
+      parts.push({
+        inlineData: {
+          data: buffer.toString("base64"),
+          mimeType: resolvedMimeType,
+        },
+      });
+    }
+
+    parts.push({
+      text: [
+        "You are a helpful creative image editor for the Hide NB Studio family app.",
+        "Use the uploaded images purely as visual references.",
+        "Blend the key elements from each reference in order, keeping the first uploads as the strongest guidance.",
+        "Follow the user's instructions precisely and return exactly one polished image.",
+        "User instructions:",
+        trimmedPrompt,
+      ].join("\n"),
+    });
+
+    const response = await client.models.generateContent({
+      model: DEFAULT_MODEL,
+      contents: [
+        {
+          role: "user",
+          parts,
+        },
+      ],
+    });
+
+    const responseParts = response.candidates?.[0]?.content?.parts ?? [];
+    const imageResult = responseParts.find((part) => part.inlineData?.data);
+    const base64Data = imageResult?.inlineData?.data;
+    const resultMime = imageResult?.inlineData?.mimeType ?? "image/png";
+
+    if (!base64Data) {
+      return NextResponse.json(
+        { error: "画像の生成に失敗しました。" },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ imageBase64: base64Data, mimeType: resultMime });
+  } catch (error) {
+    console.error("Gemini freestyle edit error", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "画像生成中に予期しないエラーが発生しました。";
+    return NextResponse.json(
+      { error: errorMessage },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -356,6 +356,95 @@
   gap: 0.6rem;
 }
 
+.multiUploadList {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.multiUploadItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.15);
+}
+
+.multiUploadHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.removeUploadButton {
+  border: none;
+  border-radius: 999px;
+  padding: 0.3rem 0.8rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.78);
+  background: rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.removeUploadButton:hover,
+.removeUploadButton:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.95);
+  transform: translateY(-1px);
+  outline: 2px solid rgba(255, 183, 3, 0.35);
+  outline-offset: 2px;
+}
+
+.multiUploadActions {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 0.5rem;
+}
+
+.addUploadButton {
+  border: 1px dashed rgba(255, 255, 255, 0.32);
+  border-radius: 12px;
+  padding: 0.75rem 1.2rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.9);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.addUploadButton:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.55);
+  transform: translateY(-1px);
+}
+
+.addUploadButton:focus-visible {
+  outline: 2px solid rgba(255, 183, 3, 0.45);
+  outline-offset: 2px;
+}
+
+.addUploadButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.fileName {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.75);
+  word-break: break-all;
+}
+
 .label {
   font-weight: 600;
   color: rgba(255, 255, 255, 0.95);


### PR DESCRIPTION
## Summary
- add a freestyle mode that accepts custom prompts and multiple reference uploads
- create a /api/freestyle-edit endpoint to send the combined request to Gemini
- extend the UI styling and progress simulation to support the new workflow

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68e0719f02cc8325bd539c9488eb4ab3