### PR TITLE
Update default Gemini image model to latest name

### DIFF
--- a/src/app/api/edit-image/route.ts
+++ b/src/app/api/edit-image/route.ts
@@ -7,7 +7,7 @@ import { MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_MB, resolveMimeType } from "@/utils/
 
 export const runtime = "nodejs";
 
-const DEFAULT_MODEL = process.env.GEMINI_IMAGE_MODEL ?? "gemini-2.5-flash-image-preview";
+const DEFAULT_MODEL = process.env.GEMINI_IMAGE_MODEL ?? "gemini-2.5-flash-image";
 
 export async function POST(request: Request) {
   const session = await getServerSession(authOptions);

--- a/src/app/api/freestyle-edit/route.ts
+++ b/src/app/api/freestyle-edit/route.ts
@@ -7,7 +7,7 @@ import { MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_MB, resolveMimeType } from "@/utils/
 
 export const runtime = "nodejs";
 
-const DEFAULT_MODEL = process.env.GEMINI_IMAGE_MODEL ?? "gemini-2.5-flash-image-preview";
+const DEFAULT_MODEL = process.env.GEMINI_IMAGE_MODEL ?? "gemini-2.5-flash-image";
 const MAX_IMAGE_COUNT = 5;
 
 export async function POST(request: Request) {


### PR DESCRIPTION
## Summary
- update the fallback Gemini image model name to `gemini-2.5-flash-image` for image editing endpoints

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e075fb9ef48325bb62f36b41ab0c12