### PR TITLE
Adjust mode description layout width

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -111,7 +111,8 @@
   font-size: 0.95rem;
   color: rgba(255, 255, 255, 0.78);
   line-height: 1.6;
-  max-width: 560px;
+  max-width: min(720px, 100%);
+  text-wrap: balance;
 }
 
 .menuOverlay {


### PR DESCRIPTION
## Summary
- update the mode description block to use a flexible max-width for better large-screen spacing
- add balanced text wrapping to improve readability of the mode description copy

## Testing
- npm run lint (passes with existing warning about an unused variable in src/utils/imageOptimization.ts)


------
https://chatgpt.com/codex/tasks/task_e_68f16b1f78d48325a807dca93f5266b7