### PR TITLE
Add prompt-only image generation mode

### DIFF
--- a/src/app/api/prompt-generate/route.ts
+++ b/src/app/api/prompt-generate/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { GoogleGenAI } from "@google/genai";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/auth";
+
+export const runtime = "nodejs";
+
+const DEFAULT_MODEL = process.env.GEMINI_IMAGE_MODEL ?? "gemini-2.5-flash-image";
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return NextResponse.json(
+      { error: "認証が必要です。" },
+      { status: 401 },
+    );
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY;
+
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: "Gemini API キーが設定されていません。" },
+      { status: 500 },
+    );
+  }
+
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "リクエスト形式が正しくありません。" },
+      { status: 400 },
+    );
+  }
+
+  const promptValue = typeof body === "object" && body !== null ? (body as { prompt?: unknown }).prompt : undefined;
+  const prompt = typeof promptValue === "string" ? promptValue.trim() : "";
+
+  if (prompt.length === 0) {
+    return NextResponse.json(
+      { error: "プロンプトを入力してください。" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const client = new GoogleGenAI({ apiKey });
+
+    const response = await client.models.generateContent({
+      model: DEFAULT_MODEL,
+      contents: [
+        {
+          role: "user",
+          parts: [
+            {
+              text: [
+                "You are a helpful creative image generator for the Hide NB Studio family app.",
+                "Produce exactly one high-quality final image based solely on the user's prompt.",
+                "Avoid adding any text, logos, or watermarks unless the user explicitly requests them.",
+                "User prompt:",
+                prompt,
+              ].join("\n"),
+            },
+          ],
+        },
+      ],
+    });
+
+    const responseParts = response.candidates?.[0]?.content?.parts ?? [];
+    const imageResult = responseParts.find((part) => part.inlineData?.data);
+    const base64Data = imageResult?.inlineData?.data;
+    const resultMime = imageResult?.inlineData?.mimeType ?? "image/png";
+
+    if (!base64Data) {
+      return NextResponse.json(
+        { error: "画像の生成に失敗しました。" },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json({ imageBase64: base64Data, mimeType: resultMime });
+  } catch (error) {
+    console.error("Gemini prompt-only generation error", error);
+    const errorMessage =
+      error instanceof Error ? error.message : "画像生成中に予期しないエラーが発生しました。";
+    return NextResponse.json(
+      { error: errorMessage },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -536,6 +536,36 @@
   color: rgba(255, 255, 255, 0.8);
 }
 
+.promptSuggestionList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.promptSuggestionButton {
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.92);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.promptSuggestionButton:hover,
+.promptSuggestionButton:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.4);
+  transform: translateY(-1px);
+}
+
+.promptSuggestionButton:focus-visible {
+  outline: 2px solid rgba(255, 183, 3, 0.5);
+  outline-offset: 2px;
+}
+
 .error {
   color: #ff6b6b;
   font-weight: 600;

--- a/src/utils/imageOptimization.ts
+++ b/src/utils/imageOptimization.ts
@@ -45,7 +45,7 @@ export async function resizeImage(file: File, options: ResizeOptions = {}): Prom
       type: file.type,
       lastModified: file.lastModified,
     });
-  } catch (error) {
+  } catch {
     // If reading fails, it might be a network/permission issue
     throw new Error('ファイルの読み込みに失敗しました。ネットワーク接続とファイルへのアクセス許可を確認してください。');
   }


### PR DESCRIPTION
## Summary
- add a new prompt-only mode in the app with guidance, simulated progress, and download support
- create a prompt-generation API route that calls Gemini without requiring reference images
- add styling for prompt suggestions and tidy image optimization lint warning

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69089f86e3c483259c94e503fbef460c