### PR TITLE
Improve prompt preset picker usability

### DIFF
--- a/src/components/PromptPicker.module.css
+++ b/src/components/PromptPicker.module.css
@@ -14,6 +14,80 @@
   font-size: 1.05rem;
 }
 
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.searchField {
+  position: relative;
+  flex: 1 1 220px;
+  display: flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.35rem 0.9rem 0.35rem 2.3rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.searchField:focus-within {
+  border-color: rgba(255, 183, 3, 0.65);
+  box-shadow: 0 0 0 3px rgba(255, 183, 3, 0.18);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.searchIcon {
+  position: absolute;
+  inset-inline-start: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.searchIconSvg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.searchInput {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 0.95rem;
+  outline: none;
+  padding: 0.4rem 0;
+}
+
+.searchInput::placeholder {
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.clearButton {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  padding: 0.35rem 0.95rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.clearButton:hover,
+.clearButton:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.3);
+  transform: translateY(-1px);
+  outline: 2px solid rgba(255, 183, 3, 0.35);
+  outline-offset: 2px;
+}
+
 .categories {
   display: flex;
   flex-direction: column;
@@ -24,6 +98,34 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem 1.1rem 1.2rem;
+}
+
+.categoryHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.categoryHeader:hover {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.categoryHeader:focus-visible {
+  outline: 2px solid rgba(255, 183, 3, 0.45);
+  border-radius: 12px;
+  outline-offset: 2px;
 }
 
 .categoryTitle {
@@ -34,10 +136,45 @@
   color: rgba(255, 183, 3, 0.9);
 }
 
+.categoryCount {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  padding: 0.15rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.collapseIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.6);
+  transition: transform 0.2s ease;
+}
+
+.collapseIconSvg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.collapseIconCollapsed {
+  transform: rotate(-90deg);
+}
+
 .options {
   display: grid;
   gap: 0.75rem;
   grid-template-columns: 1fr;
+  margin-top: 0.5rem;
+}
+
+.optionsCollapsed {
+  display: none;
 }
 
 @media (min-width: 720px) {
@@ -86,13 +223,35 @@
 .optionText {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.3rem;
 }
 
 .optionLabel {
   color: rgba(255, 255, 255, 0.98);
   font-weight: 600;
   line-height: 1.45;
+}
+
+.optionDescription {
+  color: rgba(255, 255, 255, 0.68);
+  font-size: 0.8rem;
+  line-height: 1.5;
+  max-width: 36ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.emptyState {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.9rem;
+  padding: 1.5rem 1rem;
+  text-align: center;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
 }
 
 @media (hover: none) and (pointer: coarse) {
@@ -124,7 +283,15 @@
     gap: 1.3rem;
   }
 
+  .category {
+    padding: 0.9rem 0.9rem 1rem;
+  }
+
   .option {
     padding: 1rem 1.1rem;
+  }
+
+  .optionDescription {
+    max-width: none;
   }
 }

--- a/src/components/PromptPicker.tsx
+++ b/src/components/PromptPicker.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
 import { PromptOption } from "@/promptPresets";
 import styles from "./PromptPicker.module.css";
 
@@ -11,38 +15,137 @@ type PromptPickerProps = {
 };
 
 export function PromptPicker({ groups, selectedPromptId, onSelect, legend = "プロンプトを選ぶ" }: PromptPickerProps) {
+  const [query, setQuery] = useState("");
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(() => new Set());
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const filteredEntries = useMemo(() => {
+    const entries = Object.entries(groups);
+
+    if (!normalizedQuery) {
+      return entries;
+    }
+
+    return entries
+      .map(([category, prompts]) => {
+        const filteredPrompts = prompts.filter((prompt) => {
+          const haystack = `${prompt.label} ${prompt.prompt} ${prompt.id}`.toLowerCase();
+          return haystack.includes(normalizedQuery);
+        });
+        return [category, filteredPrompts] as const;
+      })
+      .filter(([, prompts]) => prompts.length > 0);
+  }, [groups, normalizedQuery]);
+
+  const hasResults = filteredEntries.some(([, prompts]) => prompts.length > 0);
+
+  const toggleCategory = (category: string) => {
+    setCollapsedCategories((previous) => {
+      const next = new Set(previous);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  };
+
+  const resetSearch = () => {
+    setQuery("");
+  };
+
+  const getPromptPreview = (prompt: PromptOption) => {
+    const condensed = prompt.prompt.replace(/\s+/g, " ").trim();
+    if (condensed.length <= 120) {
+      return condensed;
+    }
+    return `${condensed.slice(0, 120)}…`;
+  };
+
   return (
     <fieldset className={styles.root}>
       <legend className={styles.legend}>{legend}</legend>
+
+      <div className={styles.toolbar}>
+        <label className={styles.searchField}>
+          <span className={styles.searchIcon} aria-hidden="true">
+            <svg viewBox="0 0 24 24" focusable="false" className={styles.searchIconSvg}>
+              <path
+                d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.71.71l.27.28v.79L20 20.5 20.5 20l-5-6zM10.5 15a4.5 4.5 0 1 1 0-9 4.5 4.5 0 0 1 0 9z"
+                fill="currentColor"
+              />
+            </svg>
+          </span>
+          <input
+            type="search"
+            className={styles.searchInput}
+            placeholder="キーワードで絞り込む"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </label>
+        {query && (
+          <button type="button" className={styles.clearButton} onClick={resetSearch}>
+            クリア
+          </button>
+        )}
+      </div>
+
       <div className={styles.categories}>
-        {Object.entries(groups).map(([category, prompts]) => (
-          <div key={category} className={styles.category}>
-            <h3 className={styles.categoryTitle}>{category}</h3>
-            <div className={styles.options}>
-              {prompts.map((prompt) => {
-                const isSelected = prompt.id === selectedPromptId;
-                return (
-                  <label
-                    key={prompt.id}
-                    className={`${styles.option} ${isSelected ? styles.optionSelected : ""}`.trim()}
+        {hasResults ? (
+          filteredEntries.map(([category, prompts]) => {
+            const isCollapsed = normalizedQuery ? false : collapsedCategories.has(category);
+            return (
+              <section key={category} className={styles.category}>
+                <button
+                  type="button"
+                  className={styles.categoryHeader}
+                  onClick={() => toggleCategory(category)}
+                  aria-expanded={!isCollapsed}
+                >
+                  <span className={styles.categoryTitle}>{category}</span>
+                  <span className={styles.categoryCount}>{prompts.length}</span>
+                  <span
+                    aria-hidden="true"
+                    className={`${styles.collapseIcon} ${isCollapsed ? styles.collapseIconCollapsed : ""}`.trim()}
                   >
-                    <input
-                      className={styles.radio}
-                      type="radio"
-                      name="prompt"
-                      value={prompt.id}
-                      checked={isSelected}
-                      onChange={() => onSelect(prompt.id)}
-                    />
-                    <span className={styles.optionText}>
-                      <span className={styles.optionLabel}>{prompt.label}</span>
-                    </span>
-                  </label>
-                );
-              })}
-            </div>
-          </div>
-        ))}
+                    <svg viewBox="0 0 24 24" focusable="false" className={styles.collapseIconSvg}>
+                      <path d="M7 10l5 5 5-5H7z" fill="currentColor" />
+                    </svg>
+                  </span>
+                </button>
+                <div className={`${styles.options} ${isCollapsed ? styles.optionsCollapsed : ""}`.trim()}>
+                  {prompts.map((prompt) => {
+                    const isSelected = prompt.id === selectedPromptId;
+                    return (
+                      <label
+                        key={prompt.id}
+                        className={`${styles.option} ${isSelected ? styles.optionSelected : ""}`.trim()}
+                      >
+                        <input
+                          className={styles.radio}
+                          type="radio"
+                          name="prompt"
+                          value={prompt.id}
+                          checked={isSelected}
+                          onChange={() => onSelect(prompt.id)}
+                        />
+                        <span className={styles.optionText}>
+                          <span className={styles.optionLabel}>{prompt.label}</span>
+                          <span className={styles.optionDescription}>{getPromptPreview(prompt)}</span>
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })
+        ) : (
+          <p className={styles.emptyState}>一致するプリセットが見つかりませんでした。</p>
+        )}
       </div>
     </fieldset>
   );


### PR DESCRIPTION
## Summary
- add inline search and collapsible sections to the prompt preset picker for easier navigation
- show prompt previews, counts, and refreshed styling to keep long lists manageable
- provide empty-state guidance when no presets match the current filter

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166f069cac8325a4a37f22fd883300)